### PR TITLE
fix(vaults): depreciate the use of `_sortBy` in `VaultEventsFetcher`

### DIFF
--- a/src/vaults/VaultEventsFetcher.ts
+++ b/src/vaults/VaultEventsFetcher.ts
@@ -54,7 +54,7 @@ export default class VaultEventsFetcher implements EventsFetcherInterface {
         if (event1.event.transactionIndex !== event2.event.transactionIndex)
           return event1.event.transactionIndex - event2.event.transactionIndex;
         if (event1.event.logIndex !== event2.event.logIndex) return event1.event.logIndex - event2.event.logIndex;
-        return 0;
+        throw Error("Inconsistent events");
       }
     );
     return [allEvents, timeFrom];


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

- Two events of the same transaction were not sorted correctly on the VaultFetcher. It happened for [this transaction](https://etherscan.io/tx/0x99d1dccd89a124d79cdd81e9c586da36165e72a50ba4fe5539903da7a8169f57) where the `Transfer` event was sorted before the `Deposit` event, and lead to a temporary negative balance (inside of the same tx).
- As a consequence, [this error](https://github.com/morpho-dao/morpho-rewards/blob/17af3b659a155c88dd9aea0bc590c0481a96bd9d/src/vaults/Distributor.ts#L182) was thrown when distributing rewards for the age2 epoch3 on the `maUSDC` vault
- Thu bug is coming from `_sortBy` function of lodash
- The fix is to explicitly write the sort computation using `sort` method of the array

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `yarn lint` passes with this change
- [x] `yarn test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->