### PR TITLE
fix(markets-emissions): Harmonize scripts and utils for markets emissions

### DIFF
--- a/src/ages/distributions/MarketsEmission.ts
+++ b/src/ages/distributions/MarketsEmission.ts
@@ -1,6 +1,7 @@
 export interface MarketsEmission {
   age: string;
   epoch: string;
+  epochNumber: number;
   totalEmission: string;
   snapshotProposal?: string;
   parameters: {
@@ -15,6 +16,8 @@ export interface MarketsEmission {
       supplyRate: string;
       borrowRate: string;
       borrow: string;
+      totalMarketSupply: string;
+      totalMarketBorrow: string;
     };
   };
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

The rewards markets emissions were computed in two different ways: one with a script, the other one through the API access. The two ways ended up with the same results, but not with the exact same fields: the `totalMarketSupply` and `totalMarketBorrow` were notably missing.

This PR fix the missing fields by reusing the same code everywhere, to make sure such a bug can't appear once again.

The PR also provides a way to force re-computing the emissions, notably for the script or to be used with an API.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `yarn lint` passes with this change
- [ ] `yarn test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->