### PR TITLE
feat: export user distribution per epoch

### DIFF
--- a/src/utils/computeUsersDistributions.ts
+++ b/src/utils/computeUsersDistributions.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers, providers } from "ethers";
 import { computeMerkleTree, fetchUsers, getAccumulatedEmission, userBalancesToUnclaimedTokens, sumRewards } from ".";
 import { commify, formatUnits } from "ethers/lib/utils";
 import { finishedEpochs } from "../ages/ages";
@@ -6,11 +6,62 @@ import { SUBGRAPH_URL } from "../config";
 import { StorageService } from "./StorageService";
 import { getEpochFromNumber } from "./timestampToEpoch";
 import { epochNumberToAgeEpochString } from "../helpers";
+import { EpochConfig } from "../ages";
 
 export enum DataProvider {
   Subgraph = "subgraph",
   RPC = "rpc",
 }
+
+export const computeUsersDistributionsForEpoch = async (
+  epoch: EpochConfig,
+  provider: providers.BaseProvider,
+  storageService: StorageService,
+  force?: boolean
+) => {
+  console.log(`Compute users distribution for epoch ${epoch.epochNumber}`);
+
+  const usersBalances = await fetchUsers(SUBGRAPH_URL, epoch.finalBlock ?? undefined);
+  const usersAccumulatedRewards = (
+    await Promise.all(
+      usersBalances.map(async ({ address, balances }) => ({
+        address,
+        accumulatedRewards: sumRewards(
+          await userBalancesToUnclaimedTokens(balances, epoch.finalTimestamp, provider, storageService)
+        ).toString(),
+      }))
+    )
+  ).filter(({ accumulatedRewards }) => accumulatedRewards !== "0");
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { leaves, ...merkleTree } = computeMerkleTree(usersAccumulatedRewards);
+
+  const totalEmission = getAccumulatedEmission(epoch.epochNumber);
+
+  const { age: ageName, epoch: epochName } = epochNumberToAgeEpochString(epoch.epochNumber);
+
+  await storageService.writeUsersDistribution(
+    epoch.epochNumber,
+    {
+      age: ageName,
+      epoch: epochName,
+      epochNumber: epoch.epochNumber,
+      totalEmissionInitial: formatUnits(totalEmission),
+      totalDistributed: formatUnits(merkleTree.total),
+      distribution: usersAccumulatedRewards,
+    },
+    force
+  );
+
+  await storageService.writeProofs(epoch.epochNumber, { epochNumber: epoch.epochNumber, ...merkleTree }, force);
+  return {
+    ageName,
+    epochName,
+    nbUsers: usersAccumulatedRewards.length,
+    totalEmission,
+    merkleTree,
+  };
+};
 
 export const computeUsersDistributions = async (
   dataProvider: DataProvider,
@@ -31,51 +82,24 @@ export const computeUsersDistributions = async (
 
   // Compute emissions for each epoch synchronously for throughput reasons
   for (const epoch of epochs) {
-    console.log(`Compute users distribution for epoch ${epoch.epochNumber}`);
-
-    const usersBalances = await fetchUsers(SUBGRAPH_URL, epoch.finalBlock ?? undefined);
-    const usersAccumulatedRewards = (
-      await Promise.all(
-        usersBalances.map(async ({ address, balances }) => ({
-          address,
-          accumulatedRewards: sumRewards(
-            await userBalancesToUnclaimedTokens(balances, epoch.finalTimestamp, provider, storageService)
-          ).toString(), // with 18 decimals
-        }))
-      )
-    ).filter(({ accumulatedRewards }) => accumulatedRewards !== "0");
-
-    // eslint-disable-next-line
-    const { leaves, ...merkleTree } = computeMerkleTree(usersAccumulatedRewards);
-
-    const totalEmission = getAccumulatedEmission(epoch.epochNumber);
-
-    const { age: ageName, epoch: epochName } = epochNumberToAgeEpochString(epoch.epochNumber);
-
-    await storageService.writeUsersDistribution(
-      epoch.epochNumber,
-      {
-        age: ageName,
-        epoch: epochName,
-        epochNumber: epoch.epochNumber,
-        totalEmissionInitial: formatUnits(totalEmission),
-        totalDistributed: formatUnits(merkleTree.total),
-        distribution: usersAccumulatedRewards,
-      },
+    const { ageName, epochName, nbUsers, totalEmission, merkleTree } = await computeUsersDistributionsForEpoch(
+      epoch,
+      provider,
+      storageService,
       force
     );
 
-    await storageService.writeProofs(epoch.epochNumber, { epochNumber: epoch.epochNumber, ...merkleTree }, force);
     recap.push({
       age: ageName,
       epoch: epochName,
       epochNumber: epoch.epochNumber,
-      users: usersAccumulatedRewards.length,
+      users: nbUsers,
       root: merkleTree.root,
       totalEmission: commify(formatUnits(totalEmission)),
       total: commify(formatUnits(merkleTree.total)),
     });
   }
+
   console.table(recap);
   return epochs.map((epoch) => epoch.epochNumber);
 };


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
- We need to have more granularity in functions for users distribution, in order to give the blockNumber of a finished epoch without having to write in the storage system.
- You can now call `computeUsersDistributionsForEpoch` with an epoch as input that you can override as you need 
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `yarn lint` passes with this change
- [x] `yarn test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->