### PR TITLE
feat(etherscan): try to fetch missing blocks

### DIFF
--- a/src/ages/distributions/ageFourDistribution/ageFourDistribution.ts
+++ b/src/ages/distributions/ageFourDistribution/ageFourDistribution.ts
@@ -5,13 +5,16 @@ import { parseUnits } from "ethers/lib/utils";
 import marketsRepartition from "./marketsRepartition";
 import { weightedDistribution } from "../weightedDistribution";
 import { PercentMath } from "@morpho-labs/ethers-utils/lib/maths";
+import { blockFromTimestamp } from "../../../utils";
 
 export const ageFourDistribution: DistributionFn = async (
   ageConfig: AgeDistribution,
-  { finalTimestamp, initialTimestamp, epochNumber, snapshotBlock, totalEmission }: EpochConfig,
+  { finalTimestamp, initialTimestamp, snapshotBlock, totalEmission }: EpochConfig,
   provider?: providers.Provider
 ) => {
-  if (!snapshotBlock) throw Error(`Cannot distribute tokens for epoch ${epochNumber}: no snapshotBlock`);
+  if (!snapshotBlock) {
+    snapshotBlock = +(await blockFromTimestamp(initialTimestamp, "after"));
+  }
 
   const duration = finalTimestamp.sub(initialTimestamp);
 

--- a/src/ages/distributions/ageOneDistribution.ts
+++ b/src/ages/distributions/ageOneDistribution.ts
@@ -1,12 +1,12 @@
-import { computeMarketsEmissions, getGraphMarkets } from "../../utils";
+import { blockFromTimestamp, computeMarketsEmissions, getGraphMarkets } from "../../utils";
 import { DistributionFn, EpochConfig } from "../ages.types";
 import { AgeDistribution } from "./distributions.types";
 
 export const ageOneDistribution: DistributionFn = async (
   age: AgeDistribution,
-  { snapshotBlock, totalEmission, finalTimestamp, initialTimestamp, epochNumber }: EpochConfig
+  { snapshotBlock, totalEmission, finalTimestamp, initialTimestamp }: EpochConfig
 ) => {
-  if (!snapshotBlock) throw Error(`Cannot compute distribution for epoch ${epochNumber}: snapshotBlock is missing`);
+  if (!snapshotBlock) snapshotBlock = +(await blockFromTimestamp(initialTimestamp, "after"));
   const duration = finalTimestamp.sub(initialTimestamp);
   const ageOneMarketsParameters = await getGraphMarkets(snapshotBlock);
 

--- a/src/ages/distributions/ageThreeDistribution.ts
+++ b/src/ages/distributions/ageThreeDistribution.ts
@@ -4,13 +4,14 @@ import { AgeDistribution } from "./distributions.types";
 import { parseUnits } from "ethers/lib/utils";
 import fetchProposal from "../../utils/snapshot/fetchProposal";
 import { weightedDistribution } from "./weightedDistribution";
+import { blockFromTimestamp } from "../../utils";
 
 export const ageThreeDistribution: DistributionFn = async (
   ageConfig: AgeDistribution,
   { finalTimestamp, initialTimestamp, epochNumber, snapshotBlock, snapshotProposal, totalEmission }: EpochConfig,
   provider?: providers.Provider
 ) => {
-  if (!snapshotBlock) throw Error(`Cannot distribute tokens for epoch ${epochNumber}: no snapshotBlock`);
+  if (!snapshotBlock) snapshotBlock = +(await blockFromTimestamp(initialTimestamp, "after"));
   if (!snapshotProposal) throw Error(`Cannot distribute tokens for epoch ${epochNumber}: no snapshotProposal`);
   const proposal = await fetchProposal(snapshotProposal);
 

--- a/src/ages/distributions/ageTwoDistribution.ts
+++ b/src/ages/distributions/ageTwoDistribution.ts
@@ -4,13 +4,14 @@ import { BASIS_POINTS } from "../../helpers";
 import { DistributionFn, EpochConfig } from "../ages.types";
 import { AgeDistribution } from "./distributions.types";
 import fetchMarketsData from "../../utils/markets/fetchMarketsData";
+import { blockFromTimestamp } from "../../utils";
 
 export const ageTwoDistribution: DistributionFn = async (
   epoch: AgeDistribution,
   { protocolDistribution, totalEmission, finalTimestamp, initialTimestamp, snapshotBlock, epochNumber }: EpochConfig,
   provider?: providers.Provider
 ) => {
-  if (!snapshotBlock) throw Error(`Cannot distribute tokens for ${epochNumber}: no snapshotBlock`);
+  if (!snapshotBlock) snapshotBlock = +(await blockFromTimestamp(initialTimestamp, "after"));
   provider ??= new providers.InfuraProvider("mainnet");
   if (!protocolDistribution) throw Error(`Cannot distribute tokens for ${epochNumber}: no protocolDistribution`);
 

--- a/src/utils/computeUsersDistributions.ts
+++ b/src/utils/computeUsersDistributions.ts
@@ -1,5 +1,12 @@
 import { ethers, providers } from "ethers";
-import { computeMerkleTree, fetchUsers, getAccumulatedEmission, userBalancesToUnclaimedTokens, sumRewards } from ".";
+import {
+  computeMerkleTree,
+  fetchUsers,
+  getAccumulatedEmission,
+  userBalancesToUnclaimedTokens,
+  sumRewards,
+  blockFromTimestamp,
+} from ".";
 import { commify, formatUnits } from "ethers/lib/utils";
 import { finishedEpochs } from "../ages/ages";
 import { SUBGRAPH_URL } from "../config";
@@ -20,6 +27,8 @@ export const computeUsersDistributionsForEpoch = async (
   force?: boolean
 ) => {
   console.log(`Compute users distribution for epoch ${epoch.epochNumber}`);
+  if (!epoch.finalBlock && epoch.finalTimestamp.lte(Math.floor(Date.now() / 1000)))
+    epoch.finalBlock = +(await blockFromTimestamp(epoch.finalTimestamp, "before"));
 
   const usersBalances = await fetchUsers(SUBGRAPH_URL, epoch.finalBlock ?? undefined);
   const usersAccumulatedRewards = (

--- a/src/utils/etherscan/blockFromTimestamp.ts
+++ b/src/utils/etherscan/blockFromTimestamp.ts
@@ -1,7 +1,21 @@
 import { BigNumber, BigNumberish } from "ethers";
 
-export const blockFromTimestamp = async (timestamp: BigNumberish, closest: "before" | "after", apiKey: string) =>
-  fetch(
+/**
+ * Get the block number from a timestamp
+ * @throws if no Etherscan API key is provided
+ * @throws If the timestamp is too far in the future
+ *
+ * @param timestamp in seconds
+ * @param closest "before" or "after"
+ * @param apiKey Etherscan API key
+ */
+export const blockFromTimestamp = async (
+  timestamp: BigNumberish,
+  closest: "before" | "after",
+  apiKey = process.env.ETHERSCAN_API_KEY
+) => {
+  if (!apiKey) throw new Error("No Etherscan API key provided");
+  return fetch(
     `https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${BigNumber.from(
       timestamp
     ).toString()}&closest=${closest}&apikey=${apiKey}`,
@@ -12,3 +26,4 @@ export const blockFromTimestamp = async (timestamp: BigNumberish, closest: "befo
   )
     .then((r) => r.json())
     .then((r) => r.result as string);
+};


### PR DESCRIPTION
…rror

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
- instead of throwing an error when a block is missing in any configuration, we now are trying to fetch etherscan block from the timestamp. If there is no etherscan api key provided through environment variable, then an error is thrown (no block + no api key), leading to the current behavior.

- The main use case is to prevent down time before bumping the version of morpho-rewards during epoch switch. 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `yarn lint` passes with this change
- [x] `yarn test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->